### PR TITLE
fix: format-string bug in console

### DIFF
--- a/game/dbg.cpp
+++ b/game/dbg.cpp
@@ -532,7 +532,7 @@ void ConColorMsgNoFormat( const Color &clr, const char *pszMessage )
 		gConsolePrinting.AddQueuedMessage( kColorPrint, clr, pszMessage );
 
 	if ( gpDbgConsoleFile != NULL )
-		fprintf( (FILE *)gpDbgConsoleFile, pszMessage );
+		fprintf( (FILE *)gpDbgConsoleFile, "%s", pszMessage);
 
 #ifdef LINUX
 	printf( "%s", pszMessage );


### PR DESCRIPTION
Fix a format-string bug affecting players with the `-sint_keepconsole` launch parameter and the "Chat History" HUD feature enabled.

[Video](https://drive.google.com/file/d/1XBWBJy3fsQoQxiQZcXOFZWVvR0cXLaiG/view)